### PR TITLE
Anthaue/batch

### DIFF
--- a/App.config
+++ b/App.config
@@ -65,6 +65,9 @@
             <setting name="ExperimentalLanguages" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="BatchMode" serializeAs="String">
+                <value>False</value>
+            </setting>
         </SpeechTranslator.Properties.Settings>
         <S2SMtDemoClient.Properties.Settings>
             <setting name="ClientID" serializeAs="String">
@@ -85,6 +88,9 @@
             <setting name="ToLanguageIndex" serializeAs="String">
                 <value>0</value>
             </setting>
+          <setting name="BatchMode" serializeAs="String">
+            <value>false</value>
+          </setting>
             <setting name="MiniWindow_Height" serializeAs="String">
                 <value>0</value>
             </setting>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -86,6 +86,7 @@
             </Grid>
             <Label x:Name="CutInputAudioLabel" Grid.Row="6" Grid.Column="0" Content="CUTTING INPUT AUDIO" Foreground="Blue" VerticalAlignment="Center" Visibility="Collapsed" />
             <CheckBox x:Name="BatchMode" Content="Batch Mode" Grid.Column="1" HorizontalAlignment="Left" Margin="326,10,0,0" Grid.Row="1" VerticalAlignment="Top" ToolTip="Mute speaker and translate faster than real time" Checked="BatchMode_Checked" Unchecked="BatchMode_Unchecked"/>
+            <ProgressBar x:Name="BatchProgress" Grid.Column="1" HorizontalAlignment="Left" Height="15" Margin="426,10,0,0" Grid.Row="1" VerticalAlignment="Top" Width="345" ValueChanged="ProgressBar_ValueChanged"/>
         </Grid>
         <StackPanel x:Name="Dialog" Grid.Row="2" Margin="0,0,0,0" >
             <Border x:Name="DialogRecognitionBorder" BorderThickness="5,5,5,0" BorderBrush="#FFE6E6E6">

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -58,7 +58,7 @@
             <Label Grid.Row="1" Grid.Column="0" Content="Speaker" VerticalAlignment="Center" />
             <ComboBox x:Name="Speaker" Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" Width="300" SelectionChanged="Speaker_SelectionChanged" />
             <Label x:Name="Language1Label" Grid.Row="2" Grid.Column="0" Content="From Language" VerticalAlignment="Center" />
-            <ComboBox x:Name="FromLanguage" Grid.Row="2" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" Width="200" SelectionChanged="FromLanguage_SelectionChanged"/>
+            <ComboBox x:Name="FromLanguage" Grid.Row="2" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Bottom" Width="200" SelectionChanged="FromLanguage_SelectionChanged" Margin="0,0,0,7"/>
             <Label x:Name="Language2Label" Grid.Row="3" Grid.Column="0" Content="To Language" VerticalAlignment="Center" />
             <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center">
                 <ComboBox x:Name="ToLanguage" HorizontalAlignment="Left" VerticalAlignment="Center" Width="200" SelectionChanged="ToLanguage_SelectionChanged"/>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -53,7 +53,7 @@
             <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal">
                 <ComboBox x:Name="Mic" HorizontalAlignment="Left" VerticalAlignment="Center" Width="300" SelectionChanged="Mic_SelectionChanged" />
                 <TextBox x:Name="AudioFileInput" Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" Width="400" Height="20" Margin="5"/>
-                <Button x:Name="AudioFileInputButton" Background="#FFACACAC" Grid.Row="0" Grid.Column="1" Content="Select" HorizontalAlignment="Right" Margin="5" VerticalAlignment="Stretch"  Width="60" Height="20" Click="AudioFileInputButton_Click"/>
+                <Button x:Name="AudioFileInputButton" Background="#FFACACAC" Grid.Row="0" Grid.Column="1" Content="Select" HorizontalAlignment="Right" Margin="5,8"  Width="60" Click="AudioFileInputButton_Click"/>
             </StackPanel>
             <Label Grid.Row="1" Grid.Column="0" Content="Speaker" VerticalAlignment="Center" />
             <ComboBox x:Name="Speaker" Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" Width="300" SelectionChanged="Speaker_SelectionChanged" />
@@ -81,10 +81,11 @@
                     <RowDefinition  />
                 </Grid.RowDefinitions>
                 <StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="0">
-                    <Button x:Name="StartListening" Content="Start" Background="#FFACACAC" Margin="0,2" Width="200" Click="StartListening_Click" IsDefault="True" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
+                    <Button x:Name="StartListening" Content="Start" Background="#FFACACAC" Margin="0,2,0,0" Width="200" Click="StartListening_Click" IsDefault="True" HorizontalAlignment="Stretch" Height="21" VerticalAlignment="Top"/>
                 </StackPanel>
             </Grid>
             <Label x:Name="CutInputAudioLabel" Grid.Row="6" Grid.Column="0" Content="CUTTING INPUT AUDIO" Foreground="Blue" VerticalAlignment="Center" Visibility="Collapsed" />
+            <CheckBox x:Name="BatchMode" Content="Batch Mode" Grid.Column="1" HorizontalAlignment="Left" Margin="326,10,0,0" Grid.Row="1" VerticalAlignment="Top" ToolTip="Mute speaker and translate faster than real time" Checked="BatchMode_Checked" Unchecked="BatchMode_Unchecked"/>
         </Grid>
         <StackPanel x:Name="Dialog" Grid.Row="2" Margin="0,0,0,0" >
             <Border x:Name="DialogRecognitionBorder" BorderThickness="5,5,5,0" BorderBrush="#FFE6E6E6">

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -187,6 +187,7 @@ namespace SpeechTranslator
             Voice.SelectedIndex = Properties.Settings.Default.VoiceIndex;
             MenuItem_Experimental.IsChecked = Properties.Settings.Default.ExperimentalLanguages;
             BatchProgress.Visibility = Visibility.Hidden;
+            BatchMode.IsChecked = Properties.Settings.Default.BatchMode;
 
             UpdateLanguageSettings(); 
 
@@ -210,6 +211,7 @@ namespace SpeechTranslator
             Properties.Settings.Default.ToLanguageIndex = ToLanguage.SelectedIndex;
             Properties.Settings.Default.VoiceIndex = Voice.SelectedIndex;
             Properties.Settings.Default.ExperimentalLanguages = MenuItem_Experimental.IsChecked;
+            Properties.Settings.Default.BatchMode = batchMode;
             Properties.Settings.Default.Save();
             Environment.Exit(0);
         }
@@ -229,7 +231,18 @@ namespace SpeechTranslator
                         state = UiState.MissingLanguageList;
                         this.Log(t.Exception, "E: Failed to get language list: {0}", t.IsCanceled ? "Timeout" : "");
                     }
-                    if (await checkcredentialsTask) SafeInvoke(() => UpdateUiState(state));
+                    if (await checkcredentialsTask)
+                    {
+                        SafeInvoke(() => UpdateUiState(state));
+                        if(FromLanguage.Items.Count > Properties.Settings.Default.FromLanguageIndex)
+                        {
+                            FromLanguage.SelectedIndex = Properties.Settings.Default.FromLanguageIndex;
+                        }
+                        if(ToLanguage.Items.Count > Properties.Settings.Default.ToLanguageIndex)
+                        {
+                            ToLanguage.SelectedIndex = Properties.Settings.Default.ToLanguageIndex;
+                        }
+                    }
                     else SafeInvoke(() => UpdateUiState(UiState.InvalidCredentials));
                 });
         }
@@ -424,6 +437,7 @@ namespace SpeechTranslator
                 string tag = selectedItem.Tag as string;
                 this.AudioFileInput.Visibility = (tag == "File") ? Visibility.Visible : Visibility.Collapsed;
                 this.AudioFileInputButton.Visibility = this.AudioFileInput.Visibility;
+                this.BatchMode.Visibility = this.AudioFileInput.Visibility;
                 Properties.Settings.Default.MicIndex = Mic.SelectedIndex;
             }
         }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -50,7 +50,7 @@ namespace SpeechTranslator
 
         private UiState currentState; //create a variable of enum type UiState
 
-        private Dictionary<string, string> spokenLanguages; //create dictionary for the speech translation langauges 
+        private Dictionary<string, string> spokenLanguages; //create dictionary for the speech translation languages 
         private Dictionary<string, string> textLanguages; //create dictionary for the text translation languages
         private Dictionary<string, bool> isLTR; //If this language ID is LTR or RTL
         private Dictionary<string, List<TTsDetail>> voices; //convert a list into a dictionary and call it voices TTsDetails is a class in this file
@@ -103,7 +103,7 @@ namespace SpeechTranslator
 
         private MiniWindow miniwindow = new MiniWindow();
 
-        private int screennumber = 0;   //keeps track of the screen # the miniwindow is positioned on
+        private int screennumber = 0;   //keeps track of the screen # the mini-window is positioned on
 
         private int resetcycle = 0;     //keeps track of cycling through the window positions
 
@@ -145,8 +145,8 @@ namespace SpeechTranslator
 
             Mic.SelectedIndex = Properties.Settings.Default.MicIndex;
 
-            int waveOutDevices = WaveOut.DeviceCount; //get the waveout device count
-            for (int waveOutDevice = 0; waveOutDevice < waveOutDevices; waveOutDevice++) //get all the wavout audio devices on the device and put them in a combo box
+            int waveOutDevices = WaveOut.DeviceCount; //get the wave out device count
+            for (int waveOutDevice = 0; waveOutDevice < waveOutDevices; waveOutDevice++) //get all the wave out audio devices on the device and put them in a combo box
             {
                 WaveOutCapabilities deviceInfo = WaveOut.GetCapabilities(waveOutDevice);
                 Speaker.Items.Add(new ComboBoxItem() { Content = deviceInfo.ProductName, Tag = waveOutDevice });
@@ -721,19 +721,20 @@ namespace SpeechTranslator
                         string[] audioFiles = audioFileInputPath.Split('|');
                         foreach (string currFile in audioFiles)
                         {
-                            Log($"Starting file {currFile}");
+                            Log($"I: Starting file {currFile}");
                             Task currTask = Task.Run(() => this.StreamFile(currFile, streamAudioFromFileInterrupt.Token))
                                 .ContinueWith((x) =>
                                 {
                                     if (x.IsFaulted)
                                     {
-                                        Log(x.Exception, "E: Error while playing audio from input file.");
+                                        Log(x.Exception, "E: Error while playing audio from input file {currFile}.");
                                     }
                                     else
                                     {
-                                        this.Log("I: Done playing audio from input file.");
+                                        Log($"I: Done playing audio from input file {currFile}.");
                                     }
                                 });
+                            //Don't block user thread while waiting
                             while(currTask.Status != TaskStatus.Canceled && currTask.Status != TaskStatus.Faulted && currTask.Status != TaskStatus.RanToCompletion)
                             {
                                 Thread.Sleep(1);
@@ -742,7 +743,7 @@ namespace SpeechTranslator
                     }
                     else
                     {
-                        // Start sending audio from the recoder.
+                        // Start sending audio from the recorder.
                         recorder.StartRecording();
                     }
                     this.Log("I: Connected: cid='{0}', elapsedMs='{1}'.",

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -234,14 +234,6 @@ namespace SpeechTranslator
                     if (await checkcredentialsTask)
                     {
                         SafeInvoke(() => UpdateUiState(state));
-                        if(FromLanguage.Items.Count > Properties.Settings.Default.FromLanguageIndex)
-                        {
-                            FromLanguage.SelectedIndex = Properties.Settings.Default.FromLanguageIndex;
-                        }
-                        if(ToLanguage.Items.Count > Properties.Settings.Default.ToLanguageIndex)
-                        {
-                            ToLanguage.SelectedIndex = Properties.Settings.Default.ToLanguageIndex;
-                        }
                     }
                     else SafeInvoke(() => UpdateUiState(UiState.InvalidCredentials));
                 });
@@ -322,8 +314,7 @@ namespace SpeechTranslator
                 FromLanguage.Items.Clear();
                 foreach (var language in spokenLanguages)
                 {
-                    bool isSelected = (CultureInfo.CurrentUICulture.Name.Equals(language.Key, StringComparison.OrdinalIgnoreCase)) ? true : false;
-                    FromLanguage.Items.Add(new ComboBoxItem() { Content = language.Value, Tag = language.Key, IsSelected = isSelected});
+                    FromLanguage.Items.Add(new ComboBoxItem() { Content = language.Value, Tag = language.Key});
                 }
 
                 // Gather the set of text translation languages
@@ -348,6 +339,17 @@ namespace SpeechTranslator
                 }
 
                 if (Properties.Settings.Default.FromLanguageIndex >= 0) FromLanguage.SelectedIndex = Properties.Settings.Default.FromLanguageIndex;
+                else
+                {
+                    for(int i=0; i < FromLanguage.Items.Count; ++i)
+                    {
+                        ComboBoxItem item = (ComboBoxItem)FromLanguage.Items[i];
+                        if(CultureInfo.CurrentUICulture.Name.Equals((string)item.Tag, StringComparison.OrdinalIgnoreCase))
+                        {
+                            FromLanguage.SelectedIndex = i;
+                        }
+                    }
+                }
                 if (Properties.Settings.Default.ToLanguageIndex >= 0) ToLanguage.SelectedIndex = Properties.Settings.Default.ToLanguageIndex;
                 else
                 {
@@ -851,7 +853,8 @@ namespace SpeechTranslator
         //opening the stream in order to figure out whether we're too far ahead
         //of the decoder, because the timestamps we get back from the server
         //are relative to when the stream was opened, NOT the beginning of
-        //the file.
+        //the file. So we return the number of chunks we set each time, initializing
+        //with the value from the previous call.
         private int StreamFile(string path, CancellationToken token, int initChunks)
         {
 

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -238,5 +238,17 @@ namespace SpeechTranslator.Properties {
                 this["ExperimentalLanguages"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool BatchMode {
+            get {
+                return ((bool)(this["BatchMode"]));
+            }
+            set {
+                this["BatchMode"] = value;
+            }
+        }
     }
 }

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -56,5 +56,8 @@
     <Setting Name="ExperimentalLanguages" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="BatchMode" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Shared/AudioSource.cs
+++ b/Shared/AudioSource.cs
@@ -22,6 +22,8 @@ namespace Microsoft.MT.Api.TestUtils
 
         public string SourceFile { get; private set; }
 
+        public TimeSpan Duration { get; set; }
+
         /// <summary>
         /// Creates an audio source from a WAV file (16bit PCM 16kHz - 320 bytes / 10ms).
         /// Emit the entire file (RIFF header and all sections).
@@ -42,6 +44,7 @@ namespace Microsoft.MT.Api.TestUtils
             this.SourceFile = path;
             this.data = File.ReadAllBytes(this.SourceFile);
             bool needsConversion = false;
+
 
             if (Path.GetExtension(path).ToLowerInvariant() != ".wav")
             {
@@ -72,7 +75,20 @@ namespace Microsoft.MT.Api.TestUtils
                     this.SourceFile = tempFile;
                     this.data = File.ReadAllBytes(this.SourceFile);
                 }
+                using(WaveFileReader r = new WaveFileReader(tempFile))
+                {
+                    Duration = r.TotalTime;
+                }
+
                 File.Delete(tempFile);
+            }
+            else
+            {
+                using(WaveFileReader r = new WaveFileReader(path))
+                {
+                    Duration = r.TotalTime;
+                }
+
             }
 
            

--- a/Shared/Protocol.cs
+++ b/Shared/Protocol.cs
@@ -29,6 +29,17 @@ namespace Microsoft.MT.Api
         /// Translation of the recognized text.
         [DataMember(Name = "translation", EmitDefaultValue = false)]
         public string Translation;
+
+        /// <summary>
+        /// Time offset in clicks of the start of the partial recognition in ticks relative to the beginning of streaming.
+        /// </summary>
+        [DataMember(Name = "audioTimeOffset")]
+        public string AudioTimeOffset;
+        /// <summary>
+        /// Duration in ticks of the partial recognition
+        /// </summary>
+        [DataMember(Name = "audioTimeSize")]
+        public string AudioTimeSize;
     }
 
     
@@ -50,6 +61,17 @@ namespace Microsoft.MT.Api
         /// Translation of the recognized text.
         [DataMember(Name = "translation", EmitDefaultValue = false)]
         public string Translation;
+        /// <summary>
+        /// Time offset in clicks of the start of the recognition in ticks relative to the beginning of streaming.
+        /// </summary>
+        [DataMember(Name = "audioTimeOffset")]
+        public string AudioTimeOffset;
+        /// <summary>
+        /// Duration in ticks of the recognition
+        /// </summary>
+        [DataMember(Name = "audioTimeSize")]
+        public string AudioTimeSize;
+
     }
 
    

--- a/Shared/SpeechClient.cs
+++ b/Shared/SpeechClient.cs
@@ -54,6 +54,11 @@ namespace Microsoft.MT.Api.TestUtils
             /// Gets partial speech recognitions (hypotheses)
             /// </summary>
             Partial = 2,
+
+            /// <summary>
+            /// Returns timing offsets from the beginning of the stream for recognitions.
+            /// </summary>
+            TimingInfo = 3,
         }
 
         /// <summary>
@@ -94,6 +99,8 @@ namespace Microsoft.MT.Api.TestUtils
 
         /// Queue of messages waiting to be sent.
         private BlockingCollection<QueueItem> outgoingMessageQueue = new BlockingCollection<QueueItem>();
+
+        public List<string> Errors { get; } = new List<string>();
 
         public SpeechClient(SpeechTranslateClientOptions options, CancellationToken cancellationToken)
         {
@@ -252,6 +259,7 @@ namespace Microsoft.MT.Api.TestUtils
                     {
                         case WebSocketMessageType.Close:
                             disconnecting = true;
+                            Errors.Add($"{DateTime.Now} : Disconnecting web socket with status {result.CloseStatus} for the following reason: {result.CloseStatusDescription}");
                             await this.Disconnect();
                             break;
                         case WebSocketMessageType.Binary:


### PR DESCRIPTION
Hey everyone,

These are changes to the github SpeechTranslator client, mostly for:

(1) Allowing batch translation of multiple files instead of just a single file
(2) Automatically transcoding audio where necessary
(3) As part of the way (2) is implemented, we can now decode from any audio source for which codecs have been installed, including e.g. mp4 video files
(4) In batch mode, file data is sent at better than realtime (send rate is dynamically adjusted to make sure we don't get so far ahead of ourselves that we time out the socket)
(5) Logs for recognition contain time offsets for stream and/or file.

There are a few minor things as well like making the source language persist across runs properly in settings, etc.